### PR TITLE
Add alpha option for hcl.colors pals

### DIFF
--- a/R/mf_doc_utils.R
+++ b/R/mf_doc_utils.R
@@ -43,6 +43,10 @@ my_params <- function(x) {
       "pal a set of colors or a palette name",
       " (from \\link{hcl.colors})"
     ),
+    alpha = paste0(
+      "alpha if \\code{pal} is a \\link{hcl.colors} palette name, ",
+      "the alpha-transparency level in the range [0,1]"
+    ),
     col_na = "col_na color for missing values",
     cex_na = "cex_na cex for NA values",
     pch_na = "pch_na pch for NA values",

--- a/R/mf_map.R
+++ b/R/mf_map.R
@@ -26,6 +26,7 @@
 #' "xfull",
 #' "var",
 #' "pal",
+#' "alpha",
 #' "breaks",
 #' "nbreaks",
 #' "border",
@@ -72,7 +73,7 @@
 #' mf_map(mtq)
 #' mf_map(mtq, var = c("STATUS", "MED"), type = "symb_choro")
 mf_map <- function(x, var, type = "base",
-                   breaks, nbreaks, pal,
+                   breaks, nbreaks, pal, alpha = 1,
                    inches, val_max, symbol, col,
                    lwd_max, val_order, pch, cex,
                    border, lwd, bg,

--- a/R/mf_map_c.R
+++ b/R/mf_map_c.R
@@ -8,6 +8,7 @@
 #' 'add' ,
 #' 'col_na',
 #' 'pal',
+#' 'alpha',
 #' 'breaks',
 #' 'nbreaks',
 #' 'leg_pos',
@@ -40,6 +41,7 @@
 #' )
 mf_choro <- function(x, var,
                      pal = "Mint",
+                     alpha = 1,
                      breaks = "quantile",
                      nbreaks,
                      border,
@@ -68,7 +70,7 @@ mf_choro <- function(x, var,
   breaks <- mf_get_breaks(x = x[[var]], nbreaks = nbreaks, breaks = breaks)
   nbreaks <- length(breaks) - 1
   # get the cols
-  pal <- get_the_pal(pal = pal, nbreaks = nbreaks)
+  pal <- get_the_pal(pal = pal, nbreaks = nbreaks, alpha = alpha)
   # get the color vector
   mycols <- get_col_vec(x = x[[var]], breaks = breaks, pal = pal)
 

--- a/R/mf_map_pc.R
+++ b/R/mf_map_pc.R
@@ -7,7 +7,7 @@
 #' 'border',
 #' 'lwd',
 #' 'add' ,
-#' 'inches', 'val_max', 'symbol', 'col_na', 'pal', 'breaks', 'nbreaks',
+#' 'inches', 'val_max', 'symbol', 'col_na', 'pal', 'alpha', 'breaks', 'nbreaks',
 #' 'leg_pos2', 'leg_title', 'leg_title_cex', 'leg_val_cex', 'leg_val_rnd',
 #' 'leg_no_data', 'leg_frame'))
 #'
@@ -41,6 +41,7 @@ mf_prop_choro <- function(x,
                           val_max,
                           symbol = "circle",
                           pal = "Mint",
+                          alpha = 1,
                           breaks = "quantile",
                           nbreaks,
                           border,
@@ -73,7 +74,7 @@ mf_prop_choro <- function(x,
   )
   nbreaks <- length(breaks) - 1
   # get the cols
-  pal <- get_the_pal(pal = pal, nbreaks = nbreaks)
+  pal <- get_the_pal(pal = pal, nbreaks = nbreaks, alpha = alpha)
   # get the color vector
   mycols <- get_col_vec(x = dots[[var2]], breaks = breaks, pal = pal)
 

--- a/R/mf_map_pt.R
+++ b/R/mf_map_pt.R
@@ -6,7 +6,7 @@
 #' 'border',
 #' 'lwd',
 #' 'add' ,
-#' 'inches', 'val_max', 'symbol', 'col_na', 'pal', 'leg_val_rnd',
+#' 'inches', 'val_max', 'symbol', 'col_na', 'pal', 'alpha', 'leg_val_rnd',
 #' 'leg_pos2', 'leg_title', 'leg_title_cex', 'leg_val_cex', 'val_order',
 #' 'leg_no_data', 'leg_frame'))
 #'
@@ -39,6 +39,7 @@ mf_prop_typo <- function(x, var,
                          val_max,
                          symbol = "circle",
                          pal = "Dynamic",
+                         alpha = 1,
                          val_order,
                          border,
                          lwd = .7,
@@ -69,7 +70,7 @@ mf_prop_typo <- function(x, var,
     val_order = val_order
   )
   # get color list and association
-  pal <- get_the_pal(pal = pal, nbreaks = length(val_order))
+  pal <- get_the_pal(pal = pal, nbreaks = length(val_order), alpha = alpha)
   # get color vector
   mycols <- get_col_typo(
     x = dots[[var2]], pal = pal,

--- a/R/mf_map_s.R
+++ b/R/mf_map_s.R
@@ -10,6 +10,7 @@
 #' 'cex_na',
 #' 'pch_na',
 #' 'pal',
+#' 'alpha',
 #' 'leg_pos',
 #' 'leg_title',
 #' 'leg_title_cex',
@@ -40,6 +41,7 @@
 #' )
 mf_symb <- function(x, var,
                     pal = "Dynamic",
+                    alpha = 1,
                     border,
                     pch,
                     cex = 1,
@@ -74,7 +76,7 @@ mf_symb <- function(x, var,
     val_order = val_order
   )
   # get color list and association
-  pal <- get_the_pal(pal = pal, nbreaks = length(val_order))
+  pal <- get_the_pal(pal = pal, nbreaks = length(val_order), alpha = alpha)
   # get color vector
   mycols <- get_col_typo(
     x = x[[var]], pal = pal,

--- a/R/mf_map_sc.R
+++ b/R/mf_map_sc.R
@@ -9,6 +9,7 @@
 #' 'add' ,
 #' 'col_na',
 #' 'pal',
+#' 'alpha',
 #' 'breaks',
 #' 'nbreaks',
 #' 'leg_pos2',
@@ -48,6 +49,7 @@
 #' )
 mf_symb_choro <- function(x, var,
                           pal = "Mint",
+                          alpha = 1,
                           breaks = "quantile",
                           nbreaks,
                           border,
@@ -84,7 +86,7 @@ mf_symb_choro <- function(x, var,
   breaks <- mf_get_breaks(x = x[[var2]], nbreaks = nbreaks, breaks = breaks)
   nbreaks <- length(breaks) - 1
   # get the cols
-  pal <- get_the_pal(pal = pal, nbreaks = nbreaks)
+  pal <- get_the_pal(pal = pal, nbreaks = nbreaks, alpha = alpha)
   # get the color vector
   mycols <- get_col_vec(x = x[[var2]], breaks = breaks, pal = pal)
 

--- a/R/mf_map_t.R
+++ b/R/mf_map_t.R
@@ -6,7 +6,7 @@
 #' 'border',
 #' 'lwd',
 #' 'add' ,
-#' 'col_na', 'pal',
+#' 'col_na', 'pal', 'alpha',
 #' 'leg_pos', 'leg_title', 'leg_title_cex', 'leg_val_cex', 'val_order',
 #' 'leg_no_data', 'leg_frame'))
 #' @param cex cex cex of the symbols if x is a POINT layer
@@ -33,6 +33,7 @@
 mf_typo <- function(x,
                     var,
                     pal = "Dynamic",
+                    alpha = 1,
                     val_order,
                     border,
                     pch = 21,
@@ -62,7 +63,7 @@ mf_typo <- function(x,
   )
 
   # get color list and association
-  pal <- get_the_pal(pal = pal, nbreaks = length(val_order))
+  pal <- get_the_pal(pal = pal, nbreaks = length(val_order), alpha = alpha)
   # get color vector
   mycols <- get_col_typo(
     x = x[[var]], pal = pal,

--- a/R/mf_map_utils.R
+++ b/R/mf_map_utils.R
@@ -2,12 +2,13 @@
 #'
 #' @param pal pal
 #' @param nbreaks nbreaks
+#' @param alpha alpha
 #' @noRd
 #' @importFrom grDevices hcl.pals hcl.colors
-get_the_pal <- function(pal, nbreaks) {
+get_the_pal <- function(pal, nbreaks, alpha = 1) {
   if (length(pal) == 1) {
     if (pal %in% hcl.pals()) {
-      cols <- hcl.colors(n = nbreaks, palette = pal, rev = TRUE)
+      cols <- hcl.colors(n = nbreaks, palette = pal, alpha = alpha, rev = TRUE)
     } else {
       cols <- rep(pal, nbreaks)
     }

--- a/man/mf_choro.Rd
+++ b/man/mf_choro.Rd
@@ -8,6 +8,7 @@ mf_choro(
   x,
   var,
   pal = "Mint",
+  alpha = 1,
   breaks = "quantile",
   nbreaks,
   border,
@@ -33,6 +34,8 @@ mf_choro(
 \item{var}{name(s) of the variable(s) to plot}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{breaks}{either a numeric vector with the actual breaks, or a classification method name (see \link{mf_get_breaks})}
 

--- a/man/mf_map.Rd
+++ b/man/mf_map.Rd
@@ -11,6 +11,7 @@ mf_map(
   breaks,
   nbreaks,
   pal,
+  alpha = 1,
   inches,
   val_max,
   symbol,
@@ -49,6 +50,8 @@ mf_map(
 \item{nbreaks}{number of classes}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{inches}{size of the biggest symbol (radius for circles, half width for squares) in inches.}
 

--- a/man/mf_prop_choro.Rd
+++ b/man/mf_prop_choro.Rd
@@ -11,6 +11,7 @@ mf_prop_choro(
   val_max,
   symbol = "circle",
   pal = "Mint",
+  alpha = 1,
   breaks = "quantile",
   nbreaks,
   border,
@@ -38,6 +39,8 @@ mf_prop_choro(
 \item{symbol}{type of symbols, 'circle' or 'square'}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{breaks}{either a numeric vector with the actual breaks, or a classification method name (see \link{mf_get_breaks})}
 

--- a/man/mf_prop_typo.Rd
+++ b/man/mf_prop_typo.Rd
@@ -11,6 +11,7 @@ mf_prop_typo(
   val_max,
   symbol = "circle",
   pal = "Dynamic",
+  alpha = 1,
   val_order,
   border,
   lwd = 0.7,
@@ -37,6 +38,8 @@ mf_prop_typo(
 \item{symbol}{type of symbols, 'circle' or 'square'}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{val_order}{values order, a character vector that matches var modalities}
 

--- a/man/mf_symb.Rd
+++ b/man/mf_symb.Rd
@@ -8,6 +8,7 @@ mf_symb(
   x,
   var,
   pal = "Dynamic",
+  alpha = 1,
   border,
   pch,
   cex = 1,
@@ -32,6 +33,8 @@ mf_symb(
 \item{var}{name(s) of the variable(s) to plot}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{border}{border color}
 

--- a/man/mf_symb_choro.Rd
+++ b/man/mf_symb_choro.Rd
@@ -8,6 +8,7 @@ mf_symb_choro(
   x,
   var,
   pal = "Mint",
+  alpha = 1,
   breaks = "quantile",
   nbreaks,
   border,
@@ -34,6 +35,8 @@ mf_symb_choro(
 \item{var}{name(s) of the variable(s) to plot}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{breaks}{either a numeric vector with the actual breaks, or a classification method name (see \link{mf_get_breaks})}
 

--- a/man/mf_typo.Rd
+++ b/man/mf_typo.Rd
@@ -8,6 +8,7 @@ mf_typo(
   x,
   var,
   pal = "Dynamic",
+  alpha = 1,
   val_order,
   border,
   pch = 21,
@@ -31,6 +32,8 @@ mf_typo(
 \item{var}{name(s) of the variable(s) to plot}
 
 \item{pal}{a set of colors or a palette name (from \link{hcl.colors})}
+
+\item{alpha}{if \code{pal} is a \link{hcl.colors} palette name, the alpha-transparency level in the range [0,1]}
 
 \item{val_order}{values order, a character vector that matches var modalities}
 


### PR DESCRIPTION
Salut Timothée!

Based on our discussion about using maptile layers with mapsf, I thought it would be useful to have the alpha argument of `hcl.colors` accessible via all `mf_` functions that have a `pal` argument, so that palettes can be easily mapped with transparency, retaining some visibility of the tile layer below.

Let me know your thoughts.

Paul

 